### PR TITLE
Develop

### DIFF
--- a/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
+++ b/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
@@ -5,10 +5,35 @@ using Xunit;
 
 namespace DatabaseOperations.Tests.DataTransferObjects
 {
-
 	public class ConnectionOptionsTests
 	{
         private const string BackupPath = @"C:\Database Backups\";
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedApplicationName(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.ApplicationName.Should().Be(expected.ApplicationName);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedConnectionTimeout(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.ConnectTimeout.Should().Be(expected.ConnectTimeout);
+        }
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
@@ -77,6 +102,58 @@ namespace DatabaseOperations.Tests.DataTransferObjects
             actual.CommandTimeout.Should().Be(expected.CommandTimeout);
         }
 
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedIntegratedSecurity(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.IntegratedSecurity.Should().Be(expected.IntegratedSecurity);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedPassword(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.Password.Should().Be(expected.Password);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedServer(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.Server.Should().Be(expected.Server);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedUser(string connectionString, int commandTimeout,
+	        ConnectionOptions expected)
+        {
+	        // Arrange.
+	        // Act.
+	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+
+	        // Assert.
+	        actual.UserId.Should().Be(expected.UserId);
+        }
+
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
 		internal void TestConstructorWithConnectionStringReturnsExpectedParameters(string connectionString, int commandTimeout,
@@ -98,8 +175,8 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 					continue;
 				}
 
-				var actualLocation = RemoveLastSecondFromLocation(actualParameters[i].Value.ToString());
-				var expectedLocation = RemoveLastSecondFromLocation(expectedParameters[i].Value.ToString());
+				var actualLocation = RemoveLastSecondFromLocation(actualParameters[i].Value.ToString()!);
+				var expectedLocation = RemoveLastSecondFromLocation(expectedParameters[i].Value.ToString()!);
 
 				actualLocation.Should().Be(expectedLocation);
 			}
@@ -111,26 +188,105 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
                 30,
-				GetConnectionOptions("server", "database", "127.0.0.1", "Bananas", 5, 30)
+                new ConnectionOptions("database=Bananas;", BackupPath, 30)
+	                .ApplyServer("127.0.0.1")
+	                .ApplyDatabaseName("Bananas")
+	                .ApplyUserId("sa")
+	                .ApplyPassword("password")
+	                .ApplyConnectTimeOut("205")
+	                .OverrideConnectionString("server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=5;")
 			};
 			yield return new object[]
 			{
 				"Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=1;",
                 10,
-				GetConnectionOptions("Server", "Database", "192.168.11.65", "Whoop", 5, 10)
+                new ConnectionOptions("database=Whoop;", BackupPath, 10)
+	                .ApplyServer("192.168.11.65")
+	                .ApplyDatabaseName("Whoop")
+	                .ApplyUserId("sa")
+	                .ApplyPassword("password")
+	                .ApplyConnectTimeOut("1")
+	                .OverrideConnectionString("Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=5;")
 			};
 			yield return new object[]
 			{
 				"SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
                 0,
-				GetConnectionOptions("SERVER", "DATABASE", "(localDb)", "PoohBear", 5, 60 * 60)
+                new ConnectionOptions("database=PoohBear;", BackupPath, 60 * 60)
+	                .ApplyServer("(localDb)")
+	                .ApplyDatabaseName("PoohBear")
+	                .ApplyUserId("sa")
+	                .ApplyPassword("password")
+	                .ApplyConnectTimeOut("30")
+	                .OverrideConnectionString("SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=5;")
 			};
-		}
-
-		private static ConnectionOptions GetConnectionOptions(string serverParameter, string databaseParameter, string serverName, string databaseName, int timeout, int commandTimeout)
-		{
-			var connectionString = $"{serverParameter}={serverName};{databaseParameter}={databaseName};User Id=sa;Password=password;Connect Timeout={timeout};";
-			return new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+			yield return new object[]
+			{
+				"Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;",
+				30,
+				new ConnectionOptions("database=Banana;", BackupPath, 30)
+					.ApplyServer("127.0.0.1")
+					.ApplyDatabaseName("Banana")
+					.ApplyUserId("Pooh")
+					.ApplyPassword("password")
+					.ApplyApplicationName("TestingStuff")
+					.OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;")
+			};
+			yield return new object[]
+			{
+				"Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;",
+				4,
+				new ConnectionOptions("database=Banana;", BackupPath, 4)
+					.ApplyServer("127.0.0.1")
+					.ApplyDatabaseName("Banana")
+					.ApplyConnectTimeOut("5")
+					.ApplyIntegratedSecurity("true")
+					.ApplyApplicationName("TestingStuff")
+					.OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;")
+			};
+			yield return new object[]
+			{
+				"Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
+				8,
+				new ConnectionOptions("database=Banana;", BackupPath, 8)
+					.ApplyServer("127.0.0.1")
+					.ApplyDatabaseName("Banana")
+					.ApplyConnectTimeOut("5")
+					.ApplyIntegratedSecurity("true")
+					.ApplyApplicationName("TestingStuff")
+					.OverrideConnectionString("Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
+			};
+			yield return new object[]
+			{
+				"Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
+				15,
+				new ConnectionOptions("database=Banana;", BackupPath, 15)
+					.ApplyServer("127.0.0.1")
+					.ApplyDatabaseName("Banana")
+					.ApplyConnectTimeOut("5")
+					.ApplyIntegratedSecurity("true")
+					.ApplyApplicationName("TestingStuff")
+					.OverrideConnectionString("Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
+			};
+			yield return new object[]
+			{
+				"Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;",
+				25,
+				new ConnectionOptions("database=Banana;", BackupPath, 25)
+					.ApplyServer("127.0.0.1")
+					.ApplyDatabaseName("Banana")
+					.ApplyUserId("Pooh")
+					.ApplyPassword("password")
+					.ApplyApplicationName("TestingStuff")
+					.OverrideConnectionString("Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;")
+			};
+			yield return new object[]
+			{
+				"; ;    ;;  ;Yep;Um not really;Pooh woz ere;",
+				25,
+				new ConnectionOptions(string.Empty, BackupPath, 25)
+					.OverrideConnectionString("; ;    ;;  ;Yep;Um not really;Pooh woz ere;")
+			};
 		}
 
 		private static string RemoveLastSecondFromLocation(string location)

--- a/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
+++ b/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
@@ -246,7 +246,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			};
 			yield return new object[]
 			{
-				"Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
+				"Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;",
 				8,
 				new ConnectionOptions("database=Banana;", BackupPath, 8)
 					.ApplyServer("127.0.0.1")
@@ -254,7 +254,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 					.ApplyConnectTimeOut("5")
 					.ApplyIntegratedSecurity("true")
 					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
+					.OverrideConnectionString("Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;")
 			};
 			yield return new object[]
 			{

--- a/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
+++ b/DatabaseOperations.Tests/DatabaseOperations.Tests.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DatabaseOperations.Tests/Extensions/ValidationExtensionsTests.cs
+++ b/DatabaseOperations.Tests/Extensions/ValidationExtensionsTests.cs
@@ -4,6 +4,7 @@ using DatabaseOperations.Extensions;
 using DatabaseOperations.Tests.TestTypes;
 using FluentAssertions;
 using Xunit;
+using Type = DatabaseOperations.Tests.TestTypes.Type;
 
 namespace DatabaseOperations.Tests.Extensions
 {
@@ -11,7 +12,7 @@ namespace DatabaseOperations.Tests.Extensions
 	{
 		[Theory]
 		[MemberData(nameof(GetGoodTestType))]
-		public void TestCheckValidationWithValidTestTypeReturnsTrue(TestType testType)
+		public void TestCheckValidationWithValidTestTypeReturnsTrue(Type testType)
 		{
 			// Arrange.
 			// Act.
@@ -23,7 +24,7 @@ namespace DatabaseOperations.Tests.Extensions
 
 		[Theory]
 		[MemberData(nameof(GetBadTestType))]
-		public void TestCheckValidationWithInvalidTestTypeReturnsFalse(TestType testType)
+		public void TestCheckValidationWithInvalidTestTypeReturnsFalse(Type testType)
 		{
 			// Arrange.
 			// Act.
@@ -41,29 +42,29 @@ namespace DatabaseOperations.Tests.Extensions
 			{
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 1,
-						TestName = "TestOne",
-						TestDateTime = new DateTime(2019, 01, 01)
+						Identity = 1,
+						Name = "TestOne",
+						DateTime = new DateTime(2019, 01, 01)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 2,
-						TestName = "TestTwo",
-						TestDateTime = new DateTime(2019, 01, 02)
+						Identity = 2,
+						Name = "TestTwo",
+						DateTime = new DateTime(2019, 01, 02)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 2,
-						TestName = "TestThree",
-						TestDateTime = new DateTime(2019, 01, 03)
+						Identity = 2,
+						Name = "TestThree",
+						DateTime = new DateTime(2019, 01, 03)
 					}
 				};
 			}
@@ -75,74 +76,74 @@ namespace DatabaseOperations.Tests.Extensions
 			{
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = -100,
-						TestName = "TestOne",
-						TestDateTime = new DateTime(2019, 01, 01)
+						Identity = -100,
+						Name = "TestOne",
+						DateTime = new DateTime(2019, 01, 01)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = -1,
-						TestName = "TestOne",
-						TestDateTime = new DateTime(2019, 01, 01)
+						Identity = -1,
+						Name = "TestOne",
+						DateTime = new DateTime(2019, 01, 01)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 0,
-						TestName = "TestOne",
-						TestDateTime = new DateTime(2019, 01, 01)
+						Identity = 0,
+						Name = "TestOne",
+						DateTime = new DateTime(2019, 01, 01)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 1,
-						TestName = string.Empty,
-						TestDateTime = new DateTime(2019, 01, 02)
+						Identity = 1,
+						Name = string.Empty,
+						DateTime = new DateTime(2019, 01, 02)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 2,
-						TestName = null,
-						TestDateTime = new DateTime(2019, 01, 02)
+						Identity = 2,
+						Name = null!,
+						DateTime = new DateTime(2019, 01, 02)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 2,
-						TestName = "    ",
-						TestDateTime = new DateTime(2019, 01, 02)
+						Identity = 2,
+						Name = "    ",
+						DateTime = new DateTime(2019, 01, 02)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 3,
-						TestName = "TestThree",
-						TestDateTime = new DateTime(2009, 12, 31)
+						Identity = 3,
+						Name = "TestThree",
+						DateTime = new DateTime(2009, 12, 31)
 					}
 				};
 				yield return new object[]
 				{
-					new TestType
+					new Type
 					{
-						TestIdentity = 100,
-						TestName = "TestThree",
-						TestDateTime = new DateTime(2031, 01, 01)
+						Identity = 100,
+						Name = "TestThree",
+						DateTime = new DateTime(2031, 01, 01)
 					}
 				};
 			}

--- a/DatabaseOperations.Tests/InternalConnectionOptionsExtensions.cs
+++ b/DatabaseOperations.Tests/InternalConnectionOptionsExtensions.cs
@@ -1,0 +1,55 @@
+﻿using DatabaseOperations.DataTransferObjects;
+
+namespace DatabaseOperations.Tests
+{
+    internal static class InternalConnectionOptionsExtensions
+    {
+        internal static ConnectionOptions ApplyApplicationName(this ConnectionOptions options, string applicationName)
+        {
+            options.ApplicationName = applicationName;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyConnectTimeOut(this ConnectionOptions options, string timeout)
+        {
+            options.ConnectTimeout = timeout;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyServer(this ConnectionOptions options, string serverName)
+        {
+            options.Server = serverName;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyDatabaseName(this ConnectionOptions options, string databaseName)
+        {
+            options.DatabaseName = databaseName;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyIntegratedSecurity(this ConnectionOptions options, string integratedSecurity)
+        {
+            options.IntegratedSecurity = integratedSecurity;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyPassword(this ConnectionOptions options, string password)
+        {
+            options.Password = password;
+            return options;
+        }
+
+        internal static ConnectionOptions ApplyUserId(this ConnectionOptions options, string userId)
+        {
+            options.UserId = userId;
+            return options;
+        }
+
+        internal static ConnectionOptions OverrideConnectionString(this ConnectionOptions options, string connectionString)
+        {
+            options.ConnectionString = connectionString;
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations.Tests/TestTypes/TestType.cs
+++ b/DatabaseOperations.Tests/TestTypes/TestType.cs
@@ -2,10 +2,10 @@
 
 namespace DatabaseOperations.Tests.TestTypes
 {
-    public class TestType
+    public class Type
     {
-        public int TestIdentity { get; set; }
-        public string TestName { get; set; }
-        public DateTime TestDateTime { get; set; }
+        public int Identity { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DateTime DateTime { get; set; } = DateTime.MinValue;
     }
 }

--- a/DatabaseOperations.Tests/TestTypes/TestValidator.cs
+++ b/DatabaseOperations.Tests/TestTypes/TestValidator.cs
@@ -3,14 +3,14 @@ using FluentValidation;
 
 namespace DatabaseOperations.Tests.TestTypes
 {
-    internal class TestValidator : AbstractValidator<TestType>
+    internal class TestValidator : AbstractValidator<Type>
     {
         public TestValidator()
         {
             RuleFor(test => test).NotNull();
-            RuleFor(test => test.TestIdentity).GreaterThan(0);
-            RuleFor(test => test.TestName).Must(TestNameMustNotBeNullOrWhiteSpace);
-            RuleFor(test => test.TestDateTime).InclusiveBetween(new DateTime(2010, 01, 01), new DateTime(2030, 12, 31));
+            RuleFor(test => test.Identity).GreaterThan(0);
+            RuleFor(test => test.Name).Must(TestNameMustNotBeNullOrWhiteSpace);
+            RuleFor(test => test.DateTime).InclusiveBetween(new DateTime(2010, 01, 01), new DateTime(2030, 12, 31));
         }
 
         private static bool TestNameMustNotBeNullOrWhiteSpace(string testName)

--- a/DatabaseOperations.Tests/Validators/ConnectionArrayValidatorTests.cs
+++ b/DatabaseOperations.Tests/Validators/ConnectionArrayValidatorTests.cs
@@ -15,7 +15,7 @@ namespace DatabaseOperations.Tests.Validators
 			var connectionArray = new[] { "server=127.0.0.1", "database=Bananas", "User Id=sa", "Password=password", "Connect Timeout=10" };
 
 			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
+			var results = connectionArray.CheckValidation(new ConnectionArrayValidator());
 
 			// Assert.
 			results.IsValid.Should().BeTrue();
@@ -28,7 +28,7 @@ namespace DatabaseOperations.Tests.Validators
 			var connectionArray = Array.Empty<string>();
 
 			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
+			var results = connectionArray.CheckValidation(new ConnectionArrayValidator());
 
 			// Assert.
 			results.IsValid.Should().BeFalse();
@@ -41,7 +41,7 @@ namespace DatabaseOperations.Tests.Validators
 			string[] connectionArray = { "server=127.0.0.1", "database=Bananas" };
 
 			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
+			var results = connectionArray.CheckValidation(new ConnectionArrayValidator());
 
 			// Assert.
 			results.IsValid.Should().BeFalse();
@@ -59,7 +59,7 @@ namespace DatabaseOperations.Tests.Validators
 			var connectionArray = new[] { serverItem, "database=Bananas", "User Id=sa", "Password=password", "Connect Timeout=10" };
 
 			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
+			var results = connectionArray.CheckValidation(new ConnectionArrayValidator());
 
 			// Assert.
 			results.IsValid.Should().BeFalse();
@@ -77,33 +77,7 @@ namespace DatabaseOperations.Tests.Validators
 			var connectionArray = new[] { "server=127.0.0.1", databaseItem, "User Id=sa", "Password=password", "Connect Timeout=10" };
 
 			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
-
-			// Assert.
-			results.IsValid.Should().BeFalse();
-		}
-
-		[Fact]
-		public void TestConnectionValidatorWithNullServerItemReturnsFalse()
-		{
-			// Arrange.
-			var connectionArray = new[] { null, "Bananas", "User Id=sa", "Password=password", "Connect Timeout=10" };
-
-			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
-
-			// Assert.
-			results.IsValid.Should().BeFalse();
-		}
-
-		[Fact]
-		public void TestConnectionValidatorWithNullDatabaseItemReturnsFalse()
-		{
-			// Arrange.
-			var connectionArray = new[] { "server=127.0.0.1", null, "User Id=sa", "Password=password", "Connect Timeout=10" };
-
-			// Act.
-			var results = connectionArray.CheckValidation<string[]>(new ConnectionArrayValidator());
+			var results = connectionArray.CheckValidation(new ConnectionArrayValidator());
 
 			// Assert.
 			results.IsValid.Should().BeFalse();

--- a/DatabaseOperations/ConnectionRules/AbbreviatedAddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AbbreviatedAddressConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class AbbreviatedAddressConnectionRule : IConnectionRule
+    {
+        private const string AbbreviatedAddressLookUp = "addr";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(AbbreviatedAddressLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Server)) options.Server = AbbreviatedAddressLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/AbbreviatedPasswordConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AbbreviatedPasswordConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class AbbreviatedPasswordConnectionRule : IConnectionRule
+    {
+        private const string AbbreviatedPasswordLookUp = "pwd";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(AbbreviatedPasswordLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Password)) options.Password = AbbreviatedPasswordLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/AddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/AddressConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class AddressConnectionRule : IConnectionRule
+    {
+        private const string AddressLookUp = "address";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(AddressLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Server)) options.Server = AddressLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/ApplicationConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ApplicationConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class ApplicationConnectionRule : IConnectionRule
+    {
+        private const string ApplicationNameLookUp = "application name";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(ApplicationNameLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.ApplicationName)) options.ApplicationName = ApplicationNameLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/CatalogConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/CatalogConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class CatalogConnectionRule : IConnectionRule
+    {
+        private const string InitialCatalogLookUp = "initial catalog";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(InitialCatalogLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.DatabaseName)) options.DatabaseName = InitialCatalogLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/ConnectTimeoutConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ConnectTimeoutConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class ConnectTimeoutConnectionRule : IConnectionRule
+    {
+        private const string ConnectTimeoutLookUp = "connect timeout";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(ConnectTimeoutLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.ConnectTimeout)) options.ConnectTimeout = ConnectTimeoutLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/ConnectionTimeoutConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ConnectionTimeoutConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class ConnectionTimeoutConnectionRule : IConnectionRule
+    {
+        private const string ConnectionTimeoutLookUp = "connection timeout";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(ConnectionTimeoutLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.ConnectTimeout)) options.ConnectTimeout = ConnectionTimeoutLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/DataSourceConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/DataSourceConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class DataSourceConnectionRule : IConnectionRule
+    {
+        private const string DataSourceLookUp = "data source";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(DataSourceLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Server)) options.Server = DataSourceLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/DatabaseConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/DatabaseConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class DatabaseConnectionRule : IConnectionRule
+    {
+        private const string DatabaseLookUp = "database";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(DatabaseLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.DatabaseName)) options.DatabaseName = DatabaseLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/NetworkAddressConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/NetworkAddressConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class NetworkAddressConnectionRule : IConnectionRule
+    {
+        private const string NetworkAddressLookUp = "network address";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(NetworkAddressLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Server)) options.Server = NetworkAddressLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/PasswordConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/PasswordConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class PasswordConnectionRule : IConnectionRule
+    {
+        private const string PasswordLookUp = "password";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(PasswordLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Password)) options.Password = PasswordLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/SecurityConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/SecurityConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class SecurityConnectionRule : IConnectionRule
+    {
+        private const string IntegratedSecurityLookUp = "integrated security";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(IntegratedSecurityLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.IntegratedSecurity)) options.IntegratedSecurity = IntegratedSecurityLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/ServerConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/ServerConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class ServerConnectionRule : IConnectionRule
+    {
+        private const string ServerLookUp = "server";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(ServerLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.Server)) options.Server = ServerLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/TrustedConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/TrustedConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class TrustedConnectionRule : IConnectionRule
+    {
+        private const string TrustedConnectionLookUp = "trusted_connection";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(TrustedConnectionLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.IntegratedSecurity)) options.IntegratedSecurity = TrustedConnectionLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/ConnectionRules/UserConnectionRule.cs
+++ b/DatabaseOperations/ConnectionRules/UserConnectionRule.cs
@@ -1,0 +1,22 @@
+﻿using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.ConnectionRules
+{
+    internal class UserConnectionRule : IConnectionRule
+    {
+        private const string UserIdLookUp = "user id";
+
+        public bool Check(string item)
+        {
+            return item.ToLower().Contains(UserIdLookUp);
+        }
+
+        public ConnectionOptions ApplyChange(ConnectionOptions options, string item)
+        {
+            if(string.IsNullOrWhiteSpace(options.UserId)) options.UserId = UserIdLookUp.ToValue(item);
+            return options;
+        }
+    }
+}

--- a/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
@@ -13,12 +13,38 @@ namespace DatabaseOperations.DataTransferObjects
             InitialiseProperties(connectionString, backupPath, timeout);
         }
 
-        private SqlParameter[] _parameters;
+        private SqlParameter[] _parameters = Array.Empty<SqlParameter>();
 
-        public string DatabaseName { get; private set; }
-        public string ConnectionString { get; private set; }
-        public string BackupLocation { get; private set; }
-        public string Description { get; private set; }
+        private const string ApplicationNameLookUp = "application name";
+        private const string ConnectTimeoutLookUp = "connect timeout";
+        private const string ConnectionTimeoutLookUp = "connection timeout";
+        private const string DataSourceLookUp = "data source";
+        private const string ServerLookUp = "server";
+        private const string AddressLookUp = "address";
+        private const string AbbreviatedAddressLookUp = "addr";
+        private const string NetworkAddressLookUp = "network address";
+        private const string InitialCatalogLookUp = "initial catalog";
+        private const string DatabaseLookUp = "database";
+        private const string IntegratedSecurityLookUp = "integrated security";
+        private const string TrustedConnectionLookUp = "trusted_connection";
+        private const string PasswordLookUp = "password";
+        private const string AbbreviatedPasswordLookUp = "pwd";
+        private const string UserIdLookUp = "user id";
+        private const string EqualSymbol = "=";
+
+        private readonly char[] _splitArray = {';'};
+
+        public string ApplicationName { get; internal set; } = string.Empty;
+        public string DatabaseName { get; internal set; } = string.Empty;
+        public string ConnectTimeout { get; internal set; } = string.Empty;
+        public string IntegratedSecurity { get; internal set; } = string.Empty;
+        public string Password { get; internal set; } = string.Empty;
+        public string Server { get; internal set; } = string.Empty;
+        public string UserId { get; internal set; } = string.Empty;
+
+        public string BackupLocation { get; private set; } = string.Empty;
+        public string ConnectionString { get; internal set; } = string.Empty;
+        public string Description { get; private set; } = string.Empty;
         public int CommandTimeout { get; private set; }
 
         public SqlParameter[] Parameters()
@@ -26,23 +52,120 @@ namespace DatabaseOperations.DataTransferObjects
             return _parameters;
         }
 
+        public bool IsValid()
+        {
+            // ToDo: Create a new validator for this class and return the result of that.
+            return true;
+        }
+
         private void InitialiseProperties(string connectionString, string backupPath, int timeout)
         {
-            var itemArray = connectionString.Split(';');
+            var itemArray = connectionString.Split(_splitArray, StringSplitOptions.RemoveEmptyEntries);
 
-            var database = itemArray[1].SubstringAfterValue("Database=");
-            var location = $"{backupPath}{database}_Full_{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.bak";
-            var description = $"Full backup of the `{database}` database.";
-            var updatedConnectionString = Regex.Replace(connectionString, "Connect Timeout=[0-9]{1,3}", "Connect Timeout=5");
+            // ToDo: This method needs refactoring, as it is too complex.
+            foreach (var item in itemArray)
+            {
+                switch (item)
+                {
+                    case { } itemValue when itemValue.ToLower().Contains(ApplicationNameLookUp):
+                    {
+                        ApplicationName = ToValue(ApplicationNameLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(ConnectTimeoutLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(ConnectTimeout)) ConnectTimeout = ToValue(ConnectTimeoutLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(ConnectionTimeoutLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(ConnectTimeout)) ConnectTimeout = ToValue(ConnectionTimeoutLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(DataSourceLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Server)) Server = ToValue(DataSourceLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(ServerLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Server)) Server = ToValue(ServerLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(AddressLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Server)) Server = ToValue(AddressLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(AbbreviatedAddressLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Server)) Server = ToValue(AbbreviatedAddressLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(NetworkAddressLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Server)) Server = ToValue(NetworkAddressLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(InitialCatalogLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(DatabaseName)) DatabaseName = ToValue(InitialCatalogLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(DatabaseLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(DatabaseName)) DatabaseName = ToValue(DatabaseLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(IntegratedSecurityLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(IntegratedSecurity)) IntegratedSecurity = ToValue(IntegratedSecurityLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(TrustedConnectionLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(IntegratedSecurity)) IntegratedSecurity = ToValue(TrustedConnectionLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(PasswordLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Password)) Password = ToValue(PasswordLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(AbbreviatedPasswordLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(Password)) Password = ToValue(AbbreviatedPasswordLookUp, itemValue);
+                        break;
+                    }
+                    case { } itemValue when itemValue.ToLower().Contains(UserIdLookUp):
+                    {
+                        if (string.IsNullOrWhiteSpace(UserId)) UserId = ToValue(UserIdLookUp, itemValue);
+                        break;
+                    }
+                }
+            }
 
-            DatabaseName = database;
+            var location = $"{backupPath}{DatabaseName}_Full_{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.bak";
+            var description = $"Full backup of the `{DatabaseName}` database.";
+
+            var updatedConnectionString = !string.IsNullOrWhiteSpace(ConnectTimeout)
+                ? Regex.Replace(connectionString, "Connect Timeout=[0-9]{1,3}", "Connect Timeout=5")
+                : connectionString;
+            
             ConnectionString = updatedConnectionString;
             BackupLocation = location;
             Description = description;
             CommandTimeout = SetDefaultOrTimeout(timeout);
-            _parameters = GetParameters(database, location, description, backupPath);
+            _parameters = GetParameters(DatabaseName, location, description, backupPath);
         }
 
+        private static string ToValue(string key, string value)
+        {
+            var searchString = key + EqualSymbol;
+            var newValue = value.SubstringAfterValue(searchString);
+            return newValue;
+        }
+        
         private static int SetDefaultOrTimeout(int timeout)
         {
             return timeout == 0 ? 60 * 60 : timeout;

--- a/DatabaseOperations/DataTransferObjects/OperationResult.cs
+++ b/DatabaseOperations/DataTransferObjects/OperationResult.cs
@@ -2,9 +2,9 @@
 
 namespace DatabaseOperations.DataTransferObjects
 {
-    public class OperationResult<T>
+    public class OperationResult<T> where T : new()
     {
-        public T Result { get; set; }
+        public T Result { get; set; } = new();
         public IList<string> Messages { get; set; } = new List<string>();
     }
 }

--- a/DatabaseOperations/DatabaseOperations.csproj
+++ b/DatabaseOperations/DatabaseOperations.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DatabaseOperations/Extensions/StringValueExtensions.cs
+++ b/DatabaseOperations/Extensions/StringValueExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Useful.Extensions;
+
+namespace DatabaseOperations.Extensions
+{
+    internal static class StringValueExtensions
+    {
+        private const string EqualSymbol = "=";
+
+        internal static string ToValue(this string key, string value)
+        {
+            var searchString = key + EqualSymbol;
+            var newValue = value.SubstringAfterValue(searchString);
+            return newValue;
+        }
+    }
+}

--- a/DatabaseOperations/Interfaces/IConnectionRule.cs
+++ b/DatabaseOperations/Interfaces/IConnectionRule.cs
@@ -1,0 +1,10 @@
+﻿using DatabaseOperations.DataTransferObjects;
+
+namespace DatabaseOperations.Interfaces
+{
+    internal interface IConnectionRule
+    {
+        bool Check(string item);
+        ConnectionOptions ApplyChange(ConnectionOptions options, string item);
+    }
+}


### PR DESCRIPTION
Made the connection string extractor.  Fixes #24.

Started with:
- Added the process to extract everything out of the connection string.
- Updated unit tests.
- The class needs refactoring in next commit.
- Set the projects to use the `Nullable` -> enabled.

Then refactored with this:
- The `ConnectionOptions` class can extract the connection string items out and set them as properties.
- Defined a rule list instead of a massive switch statement.
- Checked unit tests, and tweaked on to cover a bug I was introducing as I went.
- That bug is now fixed and the unit tests all pass again.