### PR TITLE
Add check that the `@BackupPath' is not null or empty

### DIFF
--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -12,7 +12,10 @@ namespace DatabaseOperations.Operators
         }
 
         private const string SqlScriptTemplate = @"
-EXEC master.dbo.xp_create_subdir @BackupPath;
+IF (@BackupPath IS NOT NULL AND @BackupPath <> '')
+BEGIN
+    EXEC master.dbo.xp_create_subdir @BackupPath;
+END
 
 BACKUP DATABASE @DatabaseName
 TO DISK = @BackupLocation


### PR DESCRIPTION
Added the check to make sure the variable '@BackupPath' is not null or empty before we try and execute the internal stored procedure to check/create the backup folder.

Fixes #23.