### PR TITLE
Set as many classes as possible to `internal`

### DIFF
--- a/DatabaseOperations.Tests/Validators/ConnectionOptionsValidatorTests.cs
+++ b/DatabaseOperations.Tests/Validators/ConnectionOptionsValidatorTests.cs
@@ -233,7 +233,7 @@ namespace DatabaseOperations.Tests.Validators
                 new ConnectionOptions("something", BackupPath, 5)
                     .ApplyServer("(localDb)")
                     .ApplyDatabaseName("Banana")
-                    .ApplyIntegratedSecurity("True")
+                    .ApplyIntegratedSecurity("False")
                     .ApplyConnectTimeOut("-1000")
             };
         }

--- a/DatabaseOperations/Constants/Parameters.cs
+++ b/DatabaseOperations/Constants/Parameters.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DatabaseOperations.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace DatabaseOperations.Constants
 {
     internal static class Parameters

--- a/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
@@ -89,7 +89,6 @@ namespace DatabaseOperations.DataTransferObjects
             var description = $"Full backup of the `{DatabaseName}` database.";
 
             ConnectionString = UpdateConnectionString(connectionString);
-            ;
             BackupLocation = location;
             Description = description;
             CommandTimeout = SetDefaultOrTimeout(timeout);

--- a/DatabaseOperations/Extensions/ValidationExtensions.cs
+++ b/DatabaseOperations/Extensions/ValidationExtensions.cs
@@ -3,9 +3,9 @@ using FluentValidation.Results;
 
 namespace DatabaseOperations.Extensions
 {
-    public static class ValidationExtensions
+    internal static class ValidationExtensions
 	{
-        public static ValidationResult CheckValidation<T>(this T component, AbstractValidator<T> validator) where T : class
+        internal static ValidationResult CheckValidation<T>(this T component, AbstractValidator<T> validator) where T : class
         {
             var result = validator.Validate(component);
             return result;

--- a/DatabaseOperations/Factories/SqlServerConnectionFactory.cs
+++ b/DatabaseOperations/Factories/SqlServerConnectionFactory.cs
@@ -3,7 +3,7 @@ using DatabaseOperations.Wrappers;
 
 namespace DatabaseOperations.Factories
 {
-    public class SqlServerConnectionFactory : ISqlServerConnectionFactory
+    internal class SqlServerConnectionFactory : ISqlServerConnectionFactory
 	{
         public ISqlConnectionWrapper CreateConnection(string connectionString)
         {

--- a/DatabaseOperations/Interfaces/ISqlCommandWrapper.cs
+++ b/DatabaseOperations/Interfaces/ISqlCommandWrapper.cs
@@ -3,7 +3,7 @@ using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Interfaces
 {
-    public interface ISqlCommandWrapper : IDisposable
+    internal interface ISqlCommandWrapper : IDisposable
     {
         SqlCommand Get();
         void AddParameters(SqlParameter[] parameters);

--- a/DatabaseOperations/Interfaces/ISqlConnectionWrapper.cs
+++ b/DatabaseOperations/Interfaces/ISqlConnectionWrapper.cs
@@ -3,7 +3,7 @@ using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Interfaces
 {
-    public interface ISqlConnectionWrapper : IDisposable
+    internal interface ISqlConnectionWrapper : IDisposable
     {
         SqlConnection Get();
         void Open();

--- a/DatabaseOperations/Interfaces/ISqlServerConnectionFactory.cs
+++ b/DatabaseOperations/Interfaces/ISqlServerConnectionFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace DatabaseOperations.Interfaces
 {
-    public interface ISqlServerConnectionFactory
+    internal interface ISqlServerConnectionFactory
 	{
         ISqlConnectionWrapper CreateConnection(string connectionString);
         ISqlCommandWrapper CreateCommand(string commandText, ISqlConnectionWrapper connection);

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -1,14 +1,20 @@
 ﻿using System.Data.Common;
 using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Factories;
 using DatabaseOperations.Interfaces;
 
 namespace DatabaseOperations.Operators
 {
     public class BackupOperator : IBackupOperator
     {
-        public BackupOperator(ISqlServerConnectionFactory creator)
+        internal BackupOperator(ISqlServerConnectionFactory creator)
         {
             _sqlCreator = creator;
+        }
+
+        public BackupOperator()
+        {
+            _sqlCreator = new SqlServerConnectionFactory();
         }
 
         private const string SqlScriptTemplate = @"

--- a/DatabaseOperations/Validators/ConnectionOptionsValidator.cs
+++ b/DatabaseOperations/Validators/ConnectionOptionsValidator.cs
@@ -5,7 +5,7 @@ namespace DatabaseOperations.Validators
 {
     internal class ConnectionOptionsValidator : AbstractValidator<ConnectionOptions>
     {
-        public ConnectionOptionsValidator()
+        internal ConnectionOptionsValidator()
         {
             RuleFor(options => options).NotNull();
             RuleFor(options => options.Server).NotNull().NotEmpty();

--- a/DatabaseOperations/Wrappers/SqlCommandWrapper.cs
+++ b/DatabaseOperations/Wrappers/SqlCommandWrapper.cs
@@ -4,9 +4,9 @@ using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Wrappers
 {
-    public sealed class SqlCommandWrapper : ISqlCommandWrapper
+    internal sealed class SqlCommandWrapper : ISqlCommandWrapper
     {
-        public SqlCommandWrapper(string commandText, ISqlConnectionWrapper sqlConnection)
+        internal SqlCommandWrapper(string commandText, ISqlConnectionWrapper sqlConnection)
         {
             _sqlCommand = new SqlCommand(commandText, sqlConnection.Get()) { CommandType = CommandType.Text };
         }

--- a/DatabaseOperations/Wrappers/SqlConnectionWrapper.cs
+++ b/DatabaseOperations/Wrappers/SqlConnectionWrapper.cs
@@ -3,9 +3,9 @@ using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Wrappers
 {
-    public sealed class SqlConnectionWrapper : ISqlConnectionWrapper
+    internal sealed class SqlConnectionWrapper : ISqlConnectionWrapper
 	{
-        public SqlConnectionWrapper(string connectionString)
+        internal SqlConnectionWrapper(string connectionString)
         {
             _sqlConnection = new SqlConnection(connectionString);
         }


### PR DESCRIPTION
- Made classes and interfaces `internal`.
- Added coverage for unit test.
- Removed random semi-colon.

Fixes #19.