### PR TITLE
Set the `backupPath` supplied to the `ConnectionOption` to use a default

### DIFF
--- a/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
+++ b/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
@@ -5,30 +5,30 @@ using Xunit;
 
 namespace DatabaseOperations.Tests.DataTransferObjects
 {
-	public class ConnectionOptionsTests
-	{
+    public class ConnectionOptionsTests
+    {
         private const string BackupPath = @"C:\Database Backups\";
 
         [Fact]
         public void TestConstructorWithEmptyConnectionStringReturnsValidationFailed()
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(string.Empty, BackupPath);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(string.Empty, BackupPath);
 
-	        // Assert.
-	        actual.IsValid().Should().BeFalse();
+            // Assert.
+            actual.IsValid().Should().BeFalse();
         }
 
         [Fact]
         public void TestConstructorWithNullConnectionStringReturnsValidationFailed()
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(null!, BackupPath);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(null!, BackupPath);
 
-	        // Assert.
-	        actual.IsValid().Should().BeFalse();
+            // Assert.
+            actual.IsValid().Should().BeFalse();
         }
 
         [Fact]
@@ -43,85 +43,85 @@ namespace DatabaseOperations.Tests.DataTransferObjects
             actual.IsValid().Should().BeTrue();
         }
 
-		[Theory]
+        [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedApplicationName(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.ApplicationName.Should().Be(expected.ApplicationName);
+            // Assert.
+            actual.ApplicationName.Should().Be(expected.ApplicationName);
         }
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedConnectionTimeout(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.ConnectTimeout.Should().Be(expected.ConnectTimeout);
+            // Assert.
+            actual.ConnectTimeout.Should().Be(expected.ConnectTimeout);
         }
 
-		[Theory]
-		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedDatabaseName(string connectionString, int commandTimeout, string backupPath,
-			ConnectionOptions expected)
-		{
-			// Arrange.
-			// Act.
-			var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
-
-			// Assert.
-			actual.DatabaseName.Should().Be(expected.DatabaseName);
-		}
-
-		[Theory]
-		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedConnectionString(string connectionString, int commandTimeout, string backupPath,
-			ConnectionOptions expected)
-		{
-			// Arrange.
-			// Act.
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedDatabaseName(string connectionString, int commandTimeout, string backupPath,
+            ConnectionOptions expected)
+        {
+            // Arrange.
+            // Act.
             var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-			// Assert.
-			actual.ConnectionString.Should().Be(expected.ConnectionString);
-		}
+            // Assert.
+            actual.DatabaseName.Should().Be(expected.DatabaseName);
+        }
 
-		[Theory]
-		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedBackupLocation(string connectionString, int commandTimeout, string backupPath,
-			ConnectionOptions expected)
-		{
-			// Arrange.
-			// Act.
-            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
-			var actualLocation = RemoveLastSecondFromLocation(actual.BackupLocation);
-			var expectedLocation = RemoveLastSecondFromLocation(expected.BackupLocation);
-
-			// Assert.
-			actualLocation.Should().Be(expectedLocation);
-		}
-
-		[Theory]
-		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedDescription(string connectionString, int commandTimeout, string backupPath,
-			ConnectionOptions expected)
-		{
-			// Arrange.
-			// Act.
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedConnectionString(string connectionString, int commandTimeout, string backupPath,
+            ConnectionOptions expected)
+        {
+            // Arrange.
+            // Act.
             var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-			// Assert.
-			actual.Description.Should().Be(expected.Description);
-		}
+            // Assert.
+            actual.ConnectionString.Should().Be(expected.ConnectionString);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedBackupLocation(string connectionString, int commandTimeout, string backupPath,
+            ConnectionOptions expected)
+        {
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            var actualLocation = RemoveLastSecondFromLocation(actual.BackupLocation);
+            var expectedLocation = RemoveLastSecondFromLocation(expected.BackupLocation);
+
+            // Assert.
+            actualLocation.Should().Be(expectedLocation);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedDescription(string connectionString, int commandTimeout, string backupPath,
+            ConnectionOptions expected)
+        {
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+
+            // Assert.
+            actual.Description.Should().Be(expected.Description);
+        }
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
@@ -139,90 +139,90 @@ namespace DatabaseOperations.Tests.DataTransferObjects
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedIntegratedSecurity(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.IntegratedSecurity.Should().Be(expected.IntegratedSecurity);
+            // Assert.
+            actual.IntegratedSecurity.Should().Be(expected.IntegratedSecurity);
         }
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedPassword(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.Password.Should().Be(expected.Password);
+            // Assert.
+            actual.Password.Should().Be(expected.Password);
         }
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedServer(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.Server.Should().Be(expected.Server);
+            // Assert.
+            actual.Server.Should().Be(expected.Server);
         }
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
         internal void TestConstructorWithConnectionStringReturnsExpectedUser(string connectionString, int commandTimeout, string backupPath,
-	        ConnectionOptions expected)
+            ConnectionOptions expected)
         {
-	        // Arrange.
-	        // Act.
-	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
+            // Arrange.
+            // Act.
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
-	        // Assert.
-	        actual.UserId.Should().Be(expected.UserId);
+            // Assert.
+            actual.UserId.Should().Be(expected.UserId);
         }
 
-		[Theory]
-		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedParameters(string connectionString, int commandTimeout, string backupPath,
-			ConnectionOptions expected)
-		{
-			// Arrange.
+        [Theory]
+        [MemberData(nameof(ConnectionStrings))]
+        internal void TestConstructorWithConnectionStringReturnsExpectedParameters(string connectionString, int commandTimeout, string backupPath,
+            ConnectionOptions expected)
+        {
+            // Arrange.
             var expectedParameters = expected.Parameters();
 
-			// Act.
+            // Act.
             var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
             var actualParameters = actual.Parameters();
 
-			// Assert.
-			for (var i = 0; i < actualParameters.Length; i++)
-			{
-				if (actualParameters[i].ParameterName != Constants.Parameters.LocationParameter)
-				{
+            // Assert.
+            for (var i = 0; i < actualParameters.Length; i++)
+            {
+                if (actualParameters[i].ParameterName != Constants.Parameters.LocationParameter)
+                {
                     actualParameters[i].Value.Should().BeEquivalentTo(expectedParameters[i].Value);
-					continue;
-				}
+                    continue;
+                }
 
-				var actualLocation = RemoveLastSecondFromLocation(actualParameters[i].Value.ToString()!);
-				var expectedLocation = RemoveLastSecondFromLocation(expectedParameters[i].Value.ToString()!);
+                var actualLocation = RemoveLastSecondFromLocation(actualParameters[i].Value.ToString()!);
+                var expectedLocation = RemoveLastSecondFromLocation(expectedParameters[i].Value.ToString()!);
 
-				actualLocation.Should().Be(expectedLocation);
-			}
-		}
+                actualLocation.Should().Be(expectedLocation);
+            }
+        }
 
-		public static IEnumerable<object[]> ConnectionStrings()
-		{
+        public static IEnumerable<object[]> ConnectionStrings()
+        {
             yield return new object[]
             {
                 "server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
                 30,
-				"",
+                "",
                 new ConnectionOptions("database=Bananas;", string.Empty, 30)
                     .ApplyServer("127.0.0.1")
                     .ApplyDatabaseName("Bananas")
@@ -231,136 +231,136 @@ namespace DatabaseOperations.Tests.DataTransferObjects
                     .ApplyConnectTimeOut("205")
                     .OverrideConnectionString("server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=5;")
             };
-			yield return new object[]
-			{
-				"server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
                 30,
-				BackupPath,
+                BackupPath,
                 new ConnectionOptions("database=Bananas;", BackupPath, 30)
-	                .ApplyServer("127.0.0.1")
-	                .ApplyDatabaseName("Bananas")
-	                .ApplyUserId("sa")
-	                .ApplyPassword("password")
-	                .ApplyConnectTimeOut("205")
-	                .OverrideConnectionString("server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=5;")
-			};
-			yield return new object[]
-			{
-				"Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=1;",
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Bananas")
+                    .ApplyUserId("sa")
+                    .ApplyPassword("password")
+                    .ApplyConnectTimeOut("205")
+                    .OverrideConnectionString("server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=5;")
+            };
+            yield return new object[]
+            {
+                "Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=1;",
                 10,
                 BackupPath,
-				new ConnectionOptions("database=Whoop;", BackupPath, 10)
-	                .ApplyServer("192.168.11.65")
-	                .ApplyDatabaseName("Whoop")
-	                .ApplyUserId("sa")
-	                .ApplyPassword("password")
-	                .ApplyConnectTimeOut("1")
-	                .OverrideConnectionString("Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=5;")
-			};
-			yield return new object[]
-			{
-				"SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
+                new ConnectionOptions("database=Whoop;", BackupPath, 10)
+                    .ApplyServer("192.168.11.65")
+                    .ApplyDatabaseName("Whoop")
+                    .ApplyUserId("sa")
+                    .ApplyPassword("password")
+                    .ApplyConnectTimeOut("1")
+                    .OverrideConnectionString("Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=5;")
+            };
+            yield return new object[]
+            {
+                "SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
                 0,
                 BackupPath,
-				new ConnectionOptions("database=PoohBear;", BackupPath, 60 * 60)
-	                .ApplyServer("(localDb)")
-	                .ApplyDatabaseName("PoohBear")
-	                .ApplyUserId("sa")
-	                .ApplyPassword("password")
-	                .ApplyConnectTimeOut("30")
-	                .OverrideConnectionString("SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=5;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;",
-				30,
+                new ConnectionOptions("database=PoohBear;", BackupPath, 60 * 60)
+                    .ApplyServer("(localDb)")
+                    .ApplyDatabaseName("PoohBear")
+                    .ApplyUserId("sa")
+                    .ApplyPassword("password")
+                    .ApplyConnectTimeOut("30")
+                    .OverrideConnectionString("SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=5;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;",
+                30,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 30)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyUserId("Pooh")
-					.ApplyPassword("password")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;",
-				4,
+                new ConnectionOptions("database=Banana;", BackupPath, 30)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyUserId("Pooh")
+                    .ApplyPassword("password")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;",
+                4,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 4)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyConnectTimeOut("5")
-					.ApplyIntegratedSecurity("true")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;",
-				8,
+                new ConnectionOptions("database=Banana;", BackupPath, 4)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyConnectTimeOut("5")
+                    .ApplyIntegratedSecurity("true")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;",
+                8,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 8)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyConnectTimeOut("5")
-					.ApplyIntegratedSecurity("true")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=false;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
-				15,
+                new ConnectionOptions("database=Banana;", BackupPath, 8)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyConnectTimeOut("5")
+                    .ApplyIntegratedSecurity("true")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=false;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
+                15,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 15)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyConnectTimeOut("5")
-					.ApplyIntegratedSecurity("false")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=false;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=SSPI;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
-				15,
+                new ConnectionOptions("database=Banana;", BackupPath, 15)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyConnectTimeOut("5")
+                    .ApplyIntegratedSecurity("false")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=false;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=SSPI;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
+                15,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 15)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyConnectTimeOut("5")
-					.ApplyIntegratedSecurity("SSPI")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=SSPI;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
-			};
-			yield return new object[]
-			{
-				"Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;",
-				25,
+                new ConnectionOptions("database=Banana;", BackupPath, 15)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyConnectTimeOut("5")
+                    .ApplyIntegratedSecurity("SSPI")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=SSPI;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;")
+            };
+            yield return new object[]
+            {
+                "Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;",
+                25,
                 BackupPath,
-				new ConnectionOptions("database=Banana;", BackupPath, 25)
-					.ApplyServer("127.0.0.1")
-					.ApplyDatabaseName("Banana")
-					.ApplyUserId("Pooh")
-					.ApplyPassword("password")
-					.ApplyApplicationName("TestingStuff")
-					.OverrideConnectionString("Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;")
-			};
-			yield return new object[]
-			{
-				"; ;    ;;  ;Yep;Um not really;Pooh woz ere;",
-				25,
+                new ConnectionOptions("database=Banana;", BackupPath, 25)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Banana")
+                    .ApplyUserId("Pooh")
+                    .ApplyPassword("password")
+                    .ApplyApplicationName("TestingStuff")
+                    .OverrideConnectionString("Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;")
+            };
+            yield return new object[]
+            {
+                "; ;    ;;  ;Yep;Um not really;Pooh woz ere;",
+                25,
                 BackupPath,
-				new ConnectionOptions("Something", BackupPath, 25)
-					.OverrideConnectionString("; ;    ;;  ;Yep;Um not really;Pooh woz ere;")
-			};
-		}
+                new ConnectionOptions("Something", BackupPath, 25)
+                    .OverrideConnectionString("; ;    ;;  ;Yep;Um not really;Pooh woz ere;")
+            };
+        }
 
-		private static string RemoveLastSecondFromLocation(string location)
-		{
-			return location[..^5];
-		}
-	}
+        private static string RemoveLastSecondFromLocation(string location)
+        {
+            return location[..^5];
+        }
+    }
 }

--- a/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
+++ b/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
@@ -30,15 +30,27 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 	        // Assert.
 	        actual.IsValid().Should().BeFalse();
         }
-        
-        [Theory]
+
+        [Fact]
+        internal void TestConstructorWithConnectionStringReturnsIsValid()
+        {
+            // Arrange.
+            const string connectionString = "server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;";
+            // Act.
+            var actual = new ConnectionOptions(connectionString);
+
+            // Assert.
+            actual.IsValid().Should().BeTrue();
+        }
+
+		[Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedApplicationName(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedApplicationName(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.ApplicationName.Should().Be(expected.ApplicationName);
@@ -46,12 +58,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedConnectionTimeout(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedConnectionTimeout(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.ConnectTimeout.Should().Be(expected.ConnectTimeout);
@@ -59,12 +71,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedDatabaseName(string connectionString, int commandTimeout,
+		internal void TestConstructorWithConnectionStringReturnsExpectedDatabaseName(string connectionString, int commandTimeout, string backupPath,
 			ConnectionOptions expected)
 		{
 			// Arrange.
 			// Act.
-			var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+			var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 			// Assert.
 			actual.DatabaseName.Should().Be(expected.DatabaseName);
@@ -72,12 +84,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedConnectionString(string connectionString, int commandTimeout,
+		internal void TestConstructorWithConnectionStringReturnsExpectedConnectionString(string connectionString, int commandTimeout, string backupPath,
 			ConnectionOptions expected)
 		{
 			// Arrange.
 			// Act.
-            var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 			// Assert.
 			actual.ConnectionString.Should().Be(expected.ConnectionString);
@@ -85,12 +97,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedBackupLocation(string connectionString, int commandTimeout,
+		internal void TestConstructorWithConnectionStringReturnsExpectedBackupLocation(string connectionString, int commandTimeout, string backupPath,
 			ConnectionOptions expected)
 		{
 			// Arrange.
 			// Act.
-            var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 			var actualLocation = RemoveLastSecondFromLocation(actual.BackupLocation);
 			var expectedLocation = RemoveLastSecondFromLocation(expected.BackupLocation);
 
@@ -100,12 +112,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedDescription(string connectionString, int commandTimeout,
+		internal void TestConstructorWithConnectionStringReturnsExpectedDescription(string connectionString, int commandTimeout, string backupPath,
 			ConnectionOptions expected)
 		{
 			// Arrange.
 			// Act.
-            var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 			// Assert.
 			actual.Description.Should().Be(expected.Description);
@@ -113,12 +125,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedCommandTimeout(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedCommandTimeout(string connectionString, int commandTimeout, string backupPath,
             ConnectionOptions expected)
         {
             // Arrange.
             // Act.
-            var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
             // Assert.
             actual.CommandTimeout.Should().Be(expected.CommandTimeout);
@@ -126,12 +138,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedIntegratedSecurity(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedIntegratedSecurity(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.IntegratedSecurity.Should().Be(expected.IntegratedSecurity);
@@ -139,12 +151,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedPassword(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedPassword(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.Password.Should().Be(expected.Password);
@@ -152,12 +164,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedServer(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedServer(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.Server.Should().Be(expected.Server);
@@ -165,12 +177,12 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
         [Theory]
         [MemberData(nameof(ConnectionStrings))]
-        internal void TestConstructorWithConnectionStringReturnsExpectedUser(string connectionString, int commandTimeout,
+        internal void TestConstructorWithConnectionStringReturnsExpectedUser(string connectionString, int commandTimeout, string backupPath,
 	        ConnectionOptions expected)
         {
 	        // Arrange.
 	        // Act.
-	        var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+	        var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
 
 	        // Assert.
 	        actual.UserId.Should().Be(expected.UserId);
@@ -178,14 +190,14 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		[Theory]
 		[MemberData(nameof(ConnectionStrings))]
-		internal void TestConstructorWithConnectionStringReturnsExpectedParameters(string connectionString, int commandTimeout,
+		internal void TestConstructorWithConnectionStringReturnsExpectedParameters(string connectionString, int commandTimeout, string backupPath,
 			ConnectionOptions expected)
 		{
 			// Arrange.
             var expectedParameters = expected.Parameters();
 
 			// Act.
-            var actual = new ConnectionOptions(connectionString, BackupPath, commandTimeout);
+            var actual = new ConnectionOptions(connectionString, backupPath, commandTimeout);
             var actualParameters = actual.Parameters();
 
 			// Assert.
@@ -206,10 +218,24 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 
 		public static IEnumerable<object[]> ConnectionStrings()
 		{
+            yield return new object[]
+            {
+                "server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
+                30,
+				"",
+                new ConnectionOptions("database=Bananas;", string.Empty, 30)
+                    .ApplyServer("127.0.0.1")
+                    .ApplyDatabaseName("Bananas")
+                    .ApplyUserId("sa")
+                    .ApplyPassword("password")
+                    .ApplyConnectTimeOut("205")
+                    .OverrideConnectionString("server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=5;")
+            };
 			yield return new object[]
 			{
 				"server=127.0.0.1;database=Bananas;User Id=sa;Password=password;Connect Timeout=205;",
                 30,
+				BackupPath,
                 new ConnectionOptions("database=Bananas;", BackupPath, 30)
 	                .ApplyServer("127.0.0.1")
 	                .ApplyDatabaseName("Bananas")
@@ -222,7 +248,8 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=192.168.11.65;Database=Whoop;User Id=sa;Password=password;Connect Timeout=1;",
                 10,
-                new ConnectionOptions("database=Whoop;", BackupPath, 10)
+                BackupPath,
+				new ConnectionOptions("database=Whoop;", BackupPath, 10)
 	                .ApplyServer("192.168.11.65")
 	                .ApplyDatabaseName("Whoop")
 	                .ApplyUserId("sa")
@@ -234,7 +261,8 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
                 0,
-                new ConnectionOptions("database=PoohBear;", BackupPath, 60 * 60)
+                BackupPath,
+				new ConnectionOptions("database=PoohBear;", BackupPath, 60 * 60)
 	                .ApplyServer("(localDb)")
 	                .ApplyDatabaseName("PoohBear")
 	                .ApplyUserId("sa")
@@ -246,6 +274,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Address=127.0.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=password;Application Name=TestingStuff;",
 				30,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 30)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -258,6 +287,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Address=127.0.0.1;Database=Banana;Integrated Security=true;Trusted_Connection=true;Connect Timeout=5;Connection Timeout=5;Application Name=TestingStuff;Um=42;",
 				4,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 4)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -270,6 +300,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Um=42;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=true;;Trusted_Connection=true;Connect Timeout=5;Um=42;Connection Timeout=6;Application Name=TestingStuff;",
 				8,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 8)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -282,6 +313,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=false;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
 				15,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 15)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -294,6 +326,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Something weird here;Address=127.0.0.1;Database=Banana;Um=42;Integrated Security=SSPI;;Trusted_Connection=true;    ;Connect Timeout=5;Um=42;Connection Timeout=5;Application Name=TestingStuff;",
 				15,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 15)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -306,6 +339,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"Server=127.0.0.1;Data Source=127.0.0.1;addr=192.168.0.1;Initial Catalog=Banana;User Id=Pooh;Password=password;Pwd=nope;Application Name=TestingStuff;",
 				25,
+                BackupPath,
 				new ConnectionOptions("database=Banana;", BackupPath, 25)
 					.ApplyServer("127.0.0.1")
 					.ApplyDatabaseName("Banana")
@@ -318,6 +352,7 @@ namespace DatabaseOperations.Tests.DataTransferObjects
 			{
 				"; ;    ;;  ;Yep;Um not really;Pooh woz ere;",
 				25,
+                BackupPath,
 				new ConnectionOptions("Something", BackupPath, 25)
 					.OverrideConnectionString("; ;    ;;  ;Yep;Um not really;Pooh woz ere;")
 			};

--- a/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
@@ -28,7 +28,7 @@ namespace DatabaseOperations.DataTransferObjects
         /// The <paramref name="timeout"/> of the execution process, not the connection to the
         /// database <paramref name="timeout"/>.
         /// </param>
-        public ConnectionOptions(string connectionString, string backupPath, int timeout = 0)
+        public ConnectionOptions(string connectionString, string backupPath = "", int timeout = 0)
         {
             InitialiseProperties(connectionString, backupPath, timeout);
         }


### PR DESCRIPTION
The `backupPath` parameter now has a default of an empty string.

Fixes #33.