### PR TITLE
Make `OperationResult` a `bool` type rather than generic

### DIFF
--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -47,7 +47,7 @@ namespace DatabaseOperations.Tests.Operators
             var details = GetConnectionOptions("server", "database", "oops", "Thing");
             _connection
                 .When(c => c.Open())
-                .Do(_ => throw  new DbTestException("Server is not correct!"));
+                .Do(_ => throw new DbTestException("Server is not correct!"));
 
             // Act.
             var result = _backupOperator.BackupDatabase(details);

--- a/DatabaseOperations/DataTransferObjects/OperationResult.cs
+++ b/DatabaseOperations/DataTransferObjects/OperationResult.cs
@@ -12,15 +12,12 @@ namespace DatabaseOperations.DataTransferObjects
     /// Messages could be errors or information about the process for logging.
     /// </para>
     /// </summary>
-    /// <typeparam name="T">
-    /// The type to be returned. Normally <see langword="bool" /> .
-    /// </typeparam>
-    public class OperationResult<T> where T : new()
+    public class OperationResult
     {
         /// <summary>
         /// The actual result from the operation.
         /// </summary>
-        public T Result { get; set; } = new();
+        public bool Result { get; set; }
 
         /// <summary>
         /// The list of messages for the consuming class.

--- a/DatabaseOperations/Interfaces/IBackupOperator.cs
+++ b/DatabaseOperations/Interfaces/IBackupOperator.cs
@@ -21,6 +21,6 @@ namespace DatabaseOperations.Interfaces
 		/// <returns>
 		/// The result of the backup operation.
 		/// </returns>
-        OperationResult<bool> BackupDatabase(ConnectionOptions options);
+        OperationResult BackupDatabase(ConnectionOptions options);
 	}
 }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -57,9 +57,9 @@ WITH
         /// <returns>
         /// The result of the backup operation.
         /// </returns>
-        public OperationResult<bool> BackupDatabase(ConnectionOptions options)
+        public OperationResult BackupDatabase(ConnectionOptions options)
         {
-            var result = new OperationResult<bool>();
+            var result = new OperationResult();
 
             if (!options.IsValid())
             {


### PR DESCRIPTION
Changed the type of `OperationResult` to just be a `bool` as the generic ability was not being used.

Updated the references as well, so it all matches.