### PR TITLE
Backup path to have default if failed

### DIFF
--- a/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
+++ b/DatabaseOperations.Tests/DataTransferObjects/ConnectionOptionsTests.cs
@@ -229,6 +229,42 @@ namespace DatabaseOperations.Tests.DataTransferObjects
             }
         }
 
+        [Fact]
+        internal void TestRemovePathReturnsPathIsNotTheSameAsBefore()
+        {
+            // Arrange.
+            var options =
+                new ConnectionOptions(
+                    "SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
+                    @"H:\Backups\");
+            var currentBackupLocation = options.BackupLocation;
+
+
+            // Act.
+            options.RemovePathFromBackupLocation();
+
+            // Assert.
+            currentBackupLocation.Should().NotBe(options.BackupLocation);
+        }
+
+        [Fact]
+        internal void TestRemovePathReturnsPathIsContainedWithinOldPath()
+        {
+            // Arrange.
+            var options =
+                new ConnectionOptions(
+                    "SERVER=(localDb);DATABASE=PoohBear;User Id=sa;Password=password;Connect Timeout=30;",
+                    @"H:\Backups\");
+            var currentBackupLocation = options.BackupLocation;
+
+
+            // Act.
+            options.RemovePathFromBackupLocation();
+
+            // Assert.
+            currentBackupLocation.Should().Contain(options.BackupLocation);
+        }
+
         public static IEnumerable<object[]> ConnectionStrings()
         {
             yield return new object[]

--- a/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
+++ b/DatabaseOperations/DataTransferObjects/ConnectionOptions.cs
@@ -7,6 +7,7 @@ using DatabaseOperations.Extensions;
 using DatabaseOperations.Interfaces;
 using DatabaseOperations.Validators;
 using Microsoft.Data.SqlClient;
+using Useful.Extensions;
 
 namespace DatabaseOperations.DataTransferObjects
 {
@@ -96,6 +97,14 @@ namespace DatabaseOperations.DataTransferObjects
             }
             
             return _isValid;
+        }
+
+        internal void RemovePathFromBackupLocation()
+        {
+            var startOfPath = BackupLocation.SubstringBeforeValue(DatabaseName);
+            var requiredLocation = BackupLocation.SubstringAfterValue(startOfPath);
+            BackupLocation = requiredLocation;
+            _executionParameters = GetParameters(DatabaseName, BackupLocation, Description);
         }
 
         private void InitialiseProperties(string connectionString, string backupPath, int timeout)

--- a/DatabaseOperations/Executors/SqlExecutor.cs
+++ b/DatabaseOperations/Executors/SqlExecutor.cs
@@ -6,7 +6,7 @@ namespace DatabaseOperations.Executors
 {
     internal class SqlExecutor : ISqlExecutor
     {
-        public SqlExecutor(ISqlServerConnectionFactory creator)
+        internal SqlExecutor(ISqlServerConnectionFactory creator)
         {
             _sqlCreator = creator;
         }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Data.Common;
 using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Executors;
 using DatabaseOperations.Factories;
 using DatabaseOperations.Interfaces;
 
@@ -14,10 +14,10 @@ namespace DatabaseOperations.Operators
         /// <summary>
         /// The <see langword="internal"/> constructor used for unit tests.
         /// </summary>
-        /// <param name="creator"> The connection factory that will allow the creation of the SQL classes. </param>
-        internal BackupOperator(ISqlServerConnectionFactory creator)
+        /// <param name="executor"> The sql executor that will execute the commands for the operations. </param>
+        internal BackupOperator(ISqlExecutor executor)
         {
-            _sqlCreator = creator;
+            _sqlExecutor = executor;
         }
 
         /// <summary>
@@ -25,27 +25,10 @@ namespace DatabaseOperations.Operators
         /// </summary>
         public BackupOperator()
         {
-            _sqlCreator = new SqlServerConnectionFactory();
+            _sqlExecutor = new SqlExecutor(new SqlServerConnectionFactory());
         }
 
-        private const string SqlScriptCreateBackupPathTemplate = @"
-IF (@BackupPath IS NOT NULL AND @BackupPath <> '')
-BEGIN
-    EXEC master.dbo.xp_create_subdir @BackupPath;
-END
-;
-";
-
-        private const string SqlScriptBackupDatabaseTemplate = @"
-BACKUP DATABASE @DatabaseName
-TO DISK = @BackupLocation
-WITH
-    NAME = @DatabaseName,
-    DESCRIPTION = @BackupDescription
-;
-";
-
-        private readonly ISqlServerConnectionFactory _sqlCreator;
+        private readonly ISqlExecutor _sqlExecutor;
 
         /// <summary>
         /// Uses the <paramref name="options" /> defined by the user to start
@@ -69,37 +52,17 @@ WITH
                 result.Messages = options.Messages;
                 return result;
             }
-            
-            try
+
+            result = _sqlExecutor.ExecuteBackupPath(result, options);
+
+            // If result.Result is not true, we want to strip out the path, so we only have the backup name.
+            if (!result.Result)
             {
-                using (var connection = _sqlCreator.CreateConnection(options.ConnectionString))
-                {
-                    using (var command = _sqlCreator.CreateCommand(SqlScriptCreateBackupPathTemplate, connection))
-                    {
-                        command.AddParameters(options.BackupParameters());
-                        command.SetCommandTimeout(options.CommandTimeout);
-                        connection.Open();
-                        command.ExecuteNonQuery();
-                    }
-                }
-                
-                using (var connection = _sqlCreator.CreateConnection(options.ConnectionString))
-                {
-                    using (var command = _sqlCreator.CreateCommand(SqlScriptBackupDatabaseTemplate, connection))
-                    {
-                        command.AddParameters(options.ExecutionParameters());
-                        command.SetCommandTimeout(options.CommandTimeout);
-                        connection.Open();
-                        command.ExecuteNonQuery();
-                    }
-                }
-                
-                result.Result = true;
+                result.Messages.Add("Unable to check the path, reverting to default save path.");
+                // Do something with the options to strip out the path.
             }
-            catch (DbException exception)
-            {
-                result.Messages.Add($"Backing up the database failed due to an exception.  Exception: {exception.Message}");
-            }
+
+            result = _sqlExecutor.ExecuteBackupDatabase(result, options);
 
             return result;
         }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -55,11 +55,11 @@ namespace DatabaseOperations.Operators
 
             result = _sqlExecutor.ExecuteBackupPath(result, options);
 
-            // If result.Result is not true, we want to strip out the path, so we only have the backup name.
+            // If result of path execution is not true, we want to strip out the path, so we only have the backup name.
             if (!result.Result)
             {
                 result.Messages.Add("Unable to check the path, reverting to default save path.");
-                // Do something with the options to strip out the path.
+                options.RemovePathFromBackupLocation();
             }
 
             result = _sqlExecutor.ExecuteBackupDatabase(result, options);


### PR DESCRIPTION
Changed the `BackupOperator` so that if the path check execution fails, it will save the backup to the default location for the server/database.

Updated unit tests and added new ones.