### PR TITLE
Add async calls to the operation

### DIFF
--- a/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
+++ b/DatabaseOperations.Tests/Executors/SqlExecutorTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using DatabaseOperations.DataTransferObjects;
 using DatabaseOperations.Executors;
 using DatabaseOperations.Interfaces;
@@ -42,6 +44,20 @@ namespace DatabaseOperations.Tests.Executors
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            var details = GetConnectionOptions("server", "database", "127.0.0.1", "Thing");
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, details, new CancellationToken());
+
+            // Assert.
+            result.Result.Should().BeTrue();
+        }
+
+        [Fact]
         public void TestBackupPathWithConnectionErrorReturnsFalse()
         {
             // Arrange.
@@ -53,6 +69,24 @@ namespace DatabaseOperations.Tests.Executors
 
             // Act.
             result = _sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupPathAsyncWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _connection
+                .When(c => c.OpenAsync(token))
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, details, token);
 
             // Assert.
             result.Result.Should().BeFalse();
@@ -76,6 +110,23 @@ namespace DatabaseOperations.Tests.Executors
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, details, new CancellationToken());
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
         public void TestBackupPathWithCommandExecuteErrorReturnsFalse()
         {
             // Arrange.
@@ -87,6 +138,24 @@ namespace DatabaseOperations.Tests.Executors
 
             // Act.
             result = _sqlExecutor.ExecuteBackupPath(result, details);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupPathAsyncWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, details, token);
 
             // Assert.
             result.Result.Should().BeFalse();
@@ -116,6 +185,30 @@ namespace DatabaseOperations.Tests.Executors
         }
 
         [Fact]
+        public async Task TestBackupPathAsyncWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+            var result = new OperationResult();
+
+            var expectedMessages = new List<string>
+            {
+                "Backup path folder check/create failed due to an exception."
+            };
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, details, token);
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithValidDetailsReturnsTrue()
         {
             // Arrange.
@@ -124,6 +217,20 @@ namespace DatabaseOperations.Tests.Executors
 
             // Act.
             result = _sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task TestBackupDatabaseAsyncWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            var details = GetConnectionOptions("server", "database", "127.0.0.1", "Thing");
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, details, new CancellationToken());
 
             // Assert.
             result.Result.Should().BeTrue();
@@ -147,6 +254,24 @@ namespace DatabaseOperations.Tests.Executors
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncWithConnectionErrorReturnsFalse()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _connection
+                .When(c => c.OpenAsync(token))
+                .Do(_ => throw new DbTestException("Server is not correct!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, details, token);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithCommandParameterErrorReturnsFalse()
         {
             // Arrange.
@@ -158,6 +283,23 @@ namespace DatabaseOperations.Tests.Executors
 
             // Act.
             result = _sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupDatabaseAsyncWithCommandParameterErrorReturnsFalse()
+        {
+            // Arrange.
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.AddParameters(Arg.Any<SqlParameter[]>()))
+                .Do(_ => throw new DbTestException("Command is not working!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, details, new CancellationToken());
 
             // Assert.
             result.Result.Should().BeFalse();
@@ -181,6 +323,24 @@ namespace DatabaseOperations.Tests.Executors
         }
 
         [Fact]
+        public async Task TestBackupDatabaseAsyncWithCommandExecuteErrorReturnsFalse()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+            var result = new OperationResult();
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, details, token);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
         public void TestBackupDatabaseWithCommandExecuteErrorReturnsExpectedMessages()
         {
             // Arrange.
@@ -197,6 +357,30 @@ namespace DatabaseOperations.Tests.Executors
 
             // Act.
             result = _sqlExecutor.ExecuteBackupDatabase(result, details);
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestBackupDatabaseAsyncWithCommandExecuteErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            var token = new CancellationToken();
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _command
+                .When(c => c.ExecuteNonQueryAsync(token))
+                .Do(_ => throw new DbTestException("Execute is not working!"));
+            var result = new OperationResult();
+
+            var expectedMessages = new List<string>
+            {
+                "Backing up the database failed due to an exception."
+            };
+
+            // Act.
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, details, token);
 
             // Assert.
             result.Messages.Should().HaveSameCount(expectedMessages);

--- a/DatabaseOperations.Tests/Extensions/OperationResultExtensionTests.cs
+++ b/DatabaseOperations.Tests/Extensions/OperationResultExtensionTests.cs
@@ -1,0 +1,399 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Extensions;
+using DatabaseOperations.Interfaces;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace DatabaseOperations.Tests.Extensions
+{
+    public class OperationResultExtensionTests
+    {
+        public OperationResultExtensionTests()
+        {
+            _tokenSource = new CancellationTokenSource();
+            _connectionOptions = new ConnectionOptions("something", @"C:\Database Backups\", 5)
+                .ApplyServer("127.0.0.1")
+                .ApplyDatabaseName("Bananas")
+                .ApplyUserId("sa")
+                .ApplyPassword("password")
+                .ApplyConnectTimeOut("205");
+            _sqlExecutor = Substitute.For<ISqlExecutor>();
+        }
+
+        private readonly CancellationTokenSource _tokenSource;
+        private readonly ConnectionOptions _connectionOptions;
+        private readonly ISqlExecutor _sqlExecutor;
+
+        [Fact]
+        public void TestValidateOptionsWithValidOptionsReturnsExpectedResult()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+
+            // Act.
+            var actual = expected.ValidateConnectionOptions(_connectionOptions);
+
+            // Assert.
+            actual.Messages.Should().BeEmpty();
+            actual.Result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void TestValidateOptionsWithInvalidOptionsReturnsExpectedResult()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _connectionOptions.ApplyServer(string.Empty);
+
+            // Act.
+            var actual = expected.ValidateConnectionOptions(_connectionOptions);
+
+            // Assert.
+            actual.Messages.Count.Should().Be(1);
+            actual.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TestExecuteBackupPathWithFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string>()
+            };
+
+            // Act.
+            var actual = expected.ExecuteBackupPath(_connectionOptions, _sqlExecutor);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            _sqlExecutor.Received(0).ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>());
+        }
+
+        [Fact]
+        public void TestExecuteBackupPathWithTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _sqlExecutor.ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>()).Returns(expected);
+
+            // Act.
+            var actual = expected.ExecuteBackupPath(_connectionOptions, _sqlExecutor);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            _sqlExecutor.Received(1).ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>());
+        }
+
+        [Fact]
+        public void TestCheckBackupPathWithMessagesResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = true,
+                Messages = new List<string>
+                {
+                    "Backup path folder check/create failed due to an exception.",
+                    "Unable to check the path, reverting to default save path."
+                }
+            };
+            var input = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string> { "Backup path folder check/create failed due to an exception." }
+            };
+
+            // Act.
+            var actual = input.CheckBackupPathExecution(_connectionOptions);
+
+            // Assert.
+            actual.Messages.Should().HaveSameCount(expected.Messages);
+            actual.Messages.Should().Equal(expected.Messages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public void TestCheckBackupPathWithNoMessagesAndFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false
+            };
+
+            // Act.
+            var actual = expected.CheckBackupPathExecution(_connectionOptions);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void TestCheckBackupPathWithNoMessagesAndTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = true
+            };
+
+            // Act.
+            var actual = expected.CheckBackupPathExecution(_connectionOptions);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void TestExecuteBackupWithFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string>()
+            };
+
+            // Act.
+            var actual = expected.ExecuteBackup(_connectionOptions, _sqlExecutor);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            _sqlExecutor.Received(0).ExecuteBackupDatabase(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>());
+        }
+
+        [Fact]
+        public void TestExecuteBackupWithTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _sqlExecutor.ExecuteBackupDatabase(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>()).Returns(expected);
+
+            // Act.
+            var actual = expected.ExecuteBackup(_connectionOptions, _sqlExecutor);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            _sqlExecutor.Received(1).ExecuteBackupDatabase(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>());
+        }
+
+        [Fact]
+        public async Task TestValidateOptionsAsyncWithValidOptionsReturnsExpectedResult()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+
+            // Act.
+            var actual = await expected.ValidateConnectionOptionsAsync(_connectionOptions).ConfigureAwait(false);
+
+            // Assert.
+            actual.Messages.Should().BeEmpty();
+            actual.Result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task TestValidateOptionsAsyncWithInvalidOptionsReturnsExpectedResult()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _connectionOptions.ApplyServer(string.Empty);
+
+            // Act.
+            var actual = await expected.ValidateConnectionOptionsAsync(_connectionOptions).ConfigureAwait(false);
+
+            // Assert.
+            actual.Messages.Count.Should().Be(1);
+            actual.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestCheckForCancellationWithFalseReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).CheckForCancellation(token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task TestCheckForCancellationWithTrueForFirstCheckReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string> { "Cancel called on the token." }
+            };
+            var input = new OperationResult();
+            var token = _tokenSource.Token;
+            _tokenSource.Cancel();
+
+            // Act.
+            var actual = await Task.FromResult(input).CheckForCancellation(token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task TestCheckForCancellationWithFalseForOtherChecksReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string> { "Cancel called on the token." }
+            };
+            var token = _tokenSource.Token;
+            _tokenSource.Cancel();
+
+            // Act.
+            var actual = await Task.FromResult(expected).CheckForCancellation(token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task TestExecuteBackupPathAsyncWithFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string>()
+            };
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).ExecuteBackupPathAsync(_connectionOptions, token, _sqlExecutor).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            await _sqlExecutor.Received(0).ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestExecuteBackupPathAsyncWithTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).Returns(expected);
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).ExecuteBackupPathAsync(_connectionOptions, token, _sqlExecutor).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            await _sqlExecutor.Received(1).ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCheckBackupPathAsyncWithMessagesResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = true,
+                Messages = new List<string>
+                {
+                    "Backup path folder check/create failed due to an exception.",
+                    "Unable to check the path, reverting to default save path."
+                }
+            };
+            var input = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string> { "Backup path folder check/create failed due to an exception." }
+            };
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(input).CheckBackupPathExecutionAsync(_connectionOptions, token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Messages.Should().HaveSameCount(expected.Messages);
+            actual.Messages.Should().Equal(expected.Messages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestCheckBackupPathAsyncWithNoMessagesAndFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false
+            };
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).CheckBackupPathExecutionAsync(_connectionOptions, token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task TestCheckBackupPathAsyncWithNoMessagesAndTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = true
+            };
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).CheckBackupPathExecutionAsync(_connectionOptions, token).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public async Task TestExecuteBackupAsyncWithFalseResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult
+            {
+                Result = false,
+                Messages = new List<string>()
+            };
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).ExecuteBackupAsync(_connectionOptions, token, _sqlExecutor).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            await _sqlExecutor.Received(0).ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestExecuteBackupAsyncWithTrueResultReturnsExpected()
+        {
+            // Arrange.
+            var expected = new OperationResult();
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).Returns(expected);
+            var token = _tokenSource.Token;
+
+            // Act.
+            var actual = await Task.FromResult(expected).ExecuteBackupAsync(_connectionOptions, token, _sqlExecutor).ConfigureAwait(false);
+
+            // Assert.
+            actual.Should().BeEquivalentTo(expected);
+            await _sqlExecutor.Received(1).ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()).ConfigureAwait(false);
+        }
+    }
+}

--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -27,7 +27,7 @@ namespace DatabaseOperations.Tests.Operators
         public void TestBackupWithValidDetailsReturnsTrue()
         {
             // Arrange.
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>())
                 .Returns(defaultResult);
             _sqlExecutor.ExecuteBackupDatabase(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>())
@@ -45,7 +45,7 @@ namespace DatabaseOperations.Tests.Operators
         public async Task TestBackupAsyncWithValidDetailsReturnsTrue()
         {
             // Arrange.
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
             _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
@@ -147,7 +147,7 @@ namespace DatabaseOperations.Tests.Operators
         public void TestBackupWithDatabaseErrorReturnsFalse()
         {
             // Arrange.
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>())
                 .Returns(defaultResult);
             var details = GetConnectionOptions("server", "database", "oops", "Thing");
@@ -165,7 +165,7 @@ namespace DatabaseOperations.Tests.Operators
         public async Task TestBackupAsyncWithDatabaseErrorReturnsFalse()
         {
             // Arrange.
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
             var details = GetConnectionOptions("server", "database", "oops", "Thing");
@@ -188,7 +188,7 @@ namespace DatabaseOperations.Tests.Operators
                 "Backing up the database failed due to an exception."
             };
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPath(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>())
                 .Returns(defaultResult);
             var details = GetConnectionOptions("server", "database", "oops", "Thing");
@@ -212,7 +212,7 @@ namespace DatabaseOperations.Tests.Operators
                 "Backing up the database failed due to an exception."
             };
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
             var details = GetConnectionOptions("server", "database", "oops", "Thing");
@@ -235,7 +235,7 @@ namespace DatabaseOperations.Tests.Operators
             var token = source.Token;
             token.ThrowIfCancellationRequested();
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
             _sqlExecutor
@@ -263,7 +263,7 @@ namespace DatabaseOperations.Tests.Operators
             var token = source.Token;
             token.ThrowIfCancellationRequested();
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
             _sqlExecutor
@@ -288,7 +288,7 @@ namespace DatabaseOperations.Tests.Operators
             var token = source.Token;
             token.ThrowIfCancellationRequested();
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
 
@@ -318,7 +318,7 @@ namespace DatabaseOperations.Tests.Operators
             var token = source.Token;
             token.ThrowIfCancellationRequested();
 
-            var defaultResult = new OperationResult { Result = true };
+            var defaultResult = new OperationResult();
             _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
                 .Returns(defaultResult);
 

--- a/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
+++ b/DatabaseOperations.Tests/Operators/BackupOperatorTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using DatabaseOperations.DataTransferObjects;
 using DatabaseOperations.Interfaces;
 using DatabaseOperations.Operators;
@@ -39,6 +42,24 @@ namespace DatabaseOperations.Tests.Operators
         }
 
         [Fact]
+        public async Task TestBackupAsyncWithValidDetailsReturnsTrue()
+        {
+            // Arrange.
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            var details = GetConnectionOptions("server", "database", "127.0.0.1", "Thing");
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, new CancellationToken());
+
+            // Assert.
+            result.Result.Should().BeTrue();
+        }
+
+        [Fact]
         public void TestBackupWithPathErrorReturnsTrue()
         {
             // Arrange.
@@ -50,6 +71,23 @@ namespace DatabaseOperations.Tests.Operators
                 .Returns(defaultResult);
             // Act.
             var result = _backupOperator.BackupDatabase(details);
+
+            // Assert.
+            result.Result.Should().BeTrue("we are reverting to the default location when backing up the database.");
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithPathErrorReturnsTrue()
+        {
+            // Arrange.
+            var defaultResult = new OperationResult { Result = true, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } };
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = false, Messages = new List<string> { "Backup path folder check/create failed due to an exception." } });
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, new CancellationToken());
 
             // Assert.
             result.Result.Should().BeTrue("we are reverting to the default location when backing up the database.");
@@ -81,6 +119,31 @@ namespace DatabaseOperations.Tests.Operators
         }
 
         [Fact]
+        public async Task TestBackupAsyncWithPathErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            var expectedMessages = new List<string>
+            {
+                "Backing up the database failed due to an exception.",
+                "Unable to check the path, reverting to default save path."
+            };
+
+            var defaultResult = new OperationResult { Result = true, Messages = expectedMessages };
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = false, Messages = expectedMessages });
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, new CancellationToken());
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
         public void TestBackupWithDatabaseErrorReturnsFalse()
         {
             // Arrange.
@@ -93,6 +156,24 @@ namespace DatabaseOperations.Tests.Operators
 
             // Act.
             var result = _backupOperator.BackupDatabase(details);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithDatabaseErrorReturnsFalse()
+        {
+            // Arrange.
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = false, Messages = new List<string> { "Backing up the database failed due to an exception." } });
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, new CancellationToken());
 
             // Assert.
             result.Result.Should().BeFalse();
@@ -116,6 +197,140 @@ namespace DatabaseOperations.Tests.Operators
 
             // Act.
             var result = _backupOperator.BackupDatabase(details);
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithDatabaseErrorReturnsExpectedMessages()
+        {
+            // Arrange.
+            var expectedMessages = new List<string>
+            {
+                "Backing up the database failed due to an exception."
+            };
+
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = false, Messages = expectedMessages });
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, new CancellationToken());
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithCancelledBackupPathReturnsFalse()
+        {
+            // Arrange.
+            var source = new CancellationTokenSource(100);
+            var token = source.Token;
+            token.ThrowIfCancellationRequested();
+
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            _sqlExecutor
+                .When(e => e.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()))
+                .Do(_ => Thread.Sleep(500));
+
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+
+            // Act.
+            var result =  await _backupOperator.BackupDatabaseAsync(details, token);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithCancelledBackupPathReturnsCancelledMessage()
+        {
+            // Arrange.
+            var expectedMessages = new List<string>
+            {
+                "Cancel called on the token."
+            };
+            var source = new CancellationTokenSource(100);
+            var token = source.Token;
+            token.ThrowIfCancellationRequested();
+
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+            _sqlExecutor
+                .When(e => e.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()))
+                .Do(_ => Thread.Sleep(500));
+
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, token);
+
+            // Assert.
+            result.Messages.Should().HaveSameCount(expectedMessages);
+            result.Messages.Should().Equal(expectedMessages, (actualMessage, expectedMessage) => actualMessage.Contains(expectedMessage));
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithCancelledBackupDatabaseReturnsFalse()
+        {
+            // Arrange.
+            var source = new CancellationTokenSource(100);
+            var token = source.Token;
+            token.ThrowIfCancellationRequested();
+
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = true });
+            _sqlExecutor
+                .When(e => e.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()))
+                .Do(_ => Thread.Sleep(500));
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, token);
+
+            // Assert.
+            result.Result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task TestBackupAsyncWithCancelledBackupDatabaseReturnsCancelledMessage()
+        {
+            // Arrange.
+            var expectedMessages = new List<string>
+            {
+                "Cancel called on the token."
+            };
+            var source = new CancellationTokenSource(100);
+            var token = source.Token;
+            token.ThrowIfCancellationRequested();
+
+            var defaultResult = new OperationResult { Result = true };
+            _sqlExecutor.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(defaultResult);
+
+            var details = GetConnectionOptions("server", "database", "oops", "Thing");
+            _sqlExecutor.ExecuteBackupDatabaseAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>())
+                .Returns(new OperationResult { Result = true });
+            _sqlExecutor
+                .When(e => e.ExecuteBackupPathAsync(Arg.Any<OperationResult>(), Arg.Any<ConnectionOptions>(), Arg.Any<CancellationToken>()))
+                .Do(_ => Thread.Sleep(500));
+
+            // Act.
+            var result = await _backupOperator.BackupDatabaseAsync(details, token);
 
             // Assert.
             result.Messages.Should().HaveSameCount(expectedMessages);

--- a/DatabaseOperations/DataTransferObjects/OperationResult.cs
+++ b/DatabaseOperations/DataTransferObjects/OperationResult.cs
@@ -17,7 +17,7 @@ namespace DatabaseOperations.DataTransferObjects
         /// <summary>
         /// The actual result from the operation.
         /// </summary>
-        public bool Result { get; set; }
+        public bool Result { get; set; } = true;
 
         /// <summary>
         /// The list of messages for the consuming class.

--- a/DatabaseOperations/Executors/SqlExecutor.cs
+++ b/DatabaseOperations/Executors/SqlExecutor.cs
@@ -46,11 +46,10 @@ WITH
                         command.ExecuteNonQuery();
                     }
                 }
-
-                result.Result = true;
             }
             catch (DbException exception)
             {
+                result.Result = false;
                 result.Messages.Add($"Backup path folder check/create failed due to an exception.  Exception: {exception.Message}");
             }
 
@@ -71,11 +70,10 @@ WITH
                         await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
                     }
                 }
-
-                result.Result = true;
             }
             catch (DbException exception)
             {
+                result.Result = false;
                 result.Messages.Add($"Backup path folder check/create failed due to an exception.  Exception: {exception.Message}");
             }
 
@@ -96,11 +94,10 @@ WITH
                         command.ExecuteNonQuery();
                     }
                 }
-
-                result.Result = true;
             }
             catch (DbException exception)
             {
+                result.Result = false;
                 result.Messages.Add($"Backing up the database failed due to an exception.  Exception: {exception.Message}");
             }
 
@@ -121,11 +118,10 @@ WITH
                         await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
                     }
                 }
-
-                result.Result = true;
             }
             catch (DbException exception)
             {
+                result.Result = false;
                 result.Messages.Add($"Backing up the database failed due to an exception.  Exception: {exception.Message}");
             }
 

--- a/DatabaseOperations/Extensions/OperationResultExtensions.cs
+++ b/DatabaseOperations/Extensions/OperationResultExtensions.cs
@@ -1,0 +1,117 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DatabaseOperations.DataTransferObjects;
+using DatabaseOperations.Interfaces;
+
+namespace DatabaseOperations.Extensions
+{
+    internal static class OperationResultExtensions
+    {
+        private const string ExecutionCancelledMessage = "Cancel called on the token.";
+        private const string BackupPathCheckFailureMessage = "Unable to check the path, reverting to default save path.";
+
+        internal static OperationResult ValidateConnectionOptions(
+            this OperationResult operationResult,
+            ConnectionOptions options)
+        {
+            if (options.IsValid()) return operationResult;
+
+            operationResult.Result = false;
+            operationResult.Messages = options.Messages;
+            return operationResult;
+        }
+
+        internal static OperationResult ExecuteBackupPath(
+            this OperationResult operationResult,
+            ConnectionOptions options,
+            ISqlExecutor sqlExecutor)
+        {
+            return !operationResult.Result ? operationResult : sqlExecutor.ExecuteBackupPath(operationResult, options);
+        }
+
+        internal static OperationResult CheckBackupPathExecution(
+            this OperationResult operationResult,
+            ConnectionOptions options)
+        {
+            if (!operationResult.Messages.Any()) return operationResult;
+
+            operationResult.Result = true;
+            operationResult.Messages.Add(BackupPathCheckFailureMessage);
+            options.RemovePathFromBackupLocation();
+
+            return operationResult;
+        }
+
+        internal static OperationResult ExecuteBackup(
+            this OperationResult operationResult,
+            ConnectionOptions options,
+            ISqlExecutor sqlExecutor)
+        {
+            return !operationResult.Result ? operationResult : sqlExecutor.ExecuteBackupDatabase(operationResult, options);
+        }
+
+        internal static async Task<OperationResult> ValidateConnectionOptionsAsync(
+            this OperationResult operationResult,
+            ConnectionOptions options)
+        {
+            if (options.IsValid()) return await Task.FromResult(operationResult).ConfigureAwait(false);
+
+            operationResult.Result = false;
+            operationResult.Messages = options.Messages;
+            return await Task.FromResult(operationResult).ConfigureAwait(false);
+        }
+
+        internal static async Task<OperationResult> CheckForCancellation(
+            this Task<OperationResult> operationResult,
+            CancellationToken token)
+        {
+            if (!token.IsCancellationRequested) return await operationResult.ConfigureAwait(false);
+
+            var result = await operationResult.ConfigureAwait(false);
+            result.Result = false;
+            if (!result.Messages.Contains(ExecutionCancelledMessage)) result.Messages.Add(ExecutionCancelledMessage);
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+
+        internal static async Task<OperationResult> ExecuteBackupPathAsync(
+            this Task<OperationResult> operationResult,
+            ConnectionOptions options,
+            CancellationToken token,
+            ISqlExecutor sqlExecutor)
+        {
+            var result = await operationResult.ConfigureAwait(false);
+            return !result.Result
+                ? await Task.FromResult(result).ConfigureAwait(false)
+                : await sqlExecutor.ExecuteBackupPathAsync(result, options, token).ConfigureAwait(false);
+        }
+
+        internal static async Task<OperationResult> CheckBackupPathExecutionAsync(
+            this Task<OperationResult> operationResult,
+            ConnectionOptions options,
+            CancellationToken token)
+        {
+            var result = await operationResult.ConfigureAwait(false);
+            if (!result.Messages.Any() || token.IsCancellationRequested) return await Task.FromResult(result).ConfigureAwait(false);
+
+            result.Result = true;
+            result.Messages.Add(BackupPathCheckFailureMessage);
+            options.RemovePathFromBackupLocation();
+
+            return await Task.FromResult(result).ConfigureAwait(false);
+        }
+
+        internal static async Task<OperationResult> ExecuteBackupAsync(
+            this Task<OperationResult> operationResult,
+            ConnectionOptions options,
+            CancellationToken token,
+            ISqlExecutor sqlExecutor)
+        {
+            var result = await operationResult.ConfigureAwait(false);
+
+            return !result.Result
+                ? await Task.FromResult(result).ConfigureAwait(false)
+                : await sqlExecutor.ExecuteBackupDatabaseAsync(result, options, token).ConfigureAwait(false);
+        }
+    }
+}

--- a/DatabaseOperations/Interfaces/IBackupOperator.cs
+++ b/DatabaseOperations/Interfaces/IBackupOperator.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DatabaseOperations.DataTransferObjects;
 
 namespace DatabaseOperations.Interfaces
@@ -22,5 +24,22 @@ namespace DatabaseOperations.Interfaces
 		/// The result of the backup operation.
 		/// </returns>
         OperationResult BackupDatabase(ConnectionOptions options);
-	}
+
+        /// <summary>
+        /// Uses the <paramref name="options" /> defined by the user to start
+        /// the backup process.
+        /// This is the async version.
+        /// </summary>
+        /// <param name="options">
+        /// The connection options defined by the consumer of the method.
+        /// </param>
+        /// <param name="token"> The cancellation token supplied by the calling application. </param>
+        /// <exception cref="NotSupportedException">
+        /// The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        /// The result of the backup operation.
+        /// </returns>
+        Task<OperationResult> BackupDatabaseAsync(ConnectionOptions options, CancellationToken token);
+    }
 }

--- a/DatabaseOperations/Interfaces/ISqlCommandWrapper.cs
+++ b/DatabaseOperations/Interfaces/ISqlCommandWrapper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Interfaces
@@ -8,5 +10,6 @@ namespace DatabaseOperations.Interfaces
 	    void AddParameters(SqlParameter[] parameters);
         void SetCommandTimeout(int timeout);
         int ExecuteNonQuery();
+        Task<int> ExecuteNonQueryAsync(CancellationToken token);
     }
 }

--- a/DatabaseOperations/Interfaces/ISqlConnectionWrapper.cs
+++ b/DatabaseOperations/Interfaces/ISqlConnectionWrapper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Interfaces
@@ -6,6 +8,9 @@ namespace DatabaseOperations.Interfaces
     internal interface ISqlConnectionWrapper : IDisposable
     {
         SqlConnection Get();
+
         void Open();
+
+        Task OpenAsync(CancellationToken token);
     }
 }

--- a/DatabaseOperations/Interfaces/ISqlExecutor.cs
+++ b/DatabaseOperations/Interfaces/ISqlExecutor.cs
@@ -1,10 +1,17 @@
-﻿using DatabaseOperations.DataTransferObjects;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DatabaseOperations.DataTransferObjects;
 
 namespace DatabaseOperations.Interfaces
 {
     internal interface ISqlExecutor
     {
         OperationResult ExecuteBackupPath(OperationResult result, ConnectionOptions options);
+
+        Task<OperationResult> ExecuteBackupPathAsync(OperationResult result, ConnectionOptions options, CancellationToken token);
+
         OperationResult ExecuteBackupDatabase(OperationResult result, ConnectionOptions options);
+
+        Task<OperationResult> ExecuteBackupDatabaseAsync(OperationResult result, ConnectionOptions options, CancellationToken token);
     }
 }

--- a/DatabaseOperations/Operators/BackupOperator.cs
+++ b/DatabaseOperations/Operators/BackupOperator.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using DatabaseOperations.DataTransferObjects;
 using DatabaseOperations.Executors;
 using DatabaseOperations.Factories;
@@ -29,6 +31,7 @@ namespace DatabaseOperations.Operators
         }
 
         private readonly ISqlExecutor _sqlExecutor;
+        private const string ExecutionCancelledMessage = "Cancel called on the token.";
 
         /// <summary>
         /// Uses the <paramref name="options" /> defined by the user to start
@@ -66,5 +69,61 @@ namespace DatabaseOperations.Operators
 
             return result;
         }
-	}
+
+        /// <summary>
+        /// Uses the <paramref name="options" /> defined by the user to start
+        /// the backup process.
+        /// This is the async version.
+        /// </summary>
+        /// <param name="options">
+        /// The connection options defined by the consumer of the method.
+        /// </param>
+        /// <param name="token"> The cancellation token supplied by the calling application. </param>
+        /// <exception cref="NotSupportedException">
+        /// The database exception was not added to the 'Message' list.
+        /// </exception>
+        /// <returns>
+        /// The result of the backup operation.
+        /// </returns>
+        public async Task<OperationResult> BackupDatabaseAsync(ConnectionOptions options, CancellationToken token = default)
+        {
+            var result = new OperationResult();
+
+            if (!options.IsValid())
+            {
+                result.Messages = options.Messages;
+                return result;
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                result.Messages.Add(ExecutionCancelledMessage);
+                return result;
+            }
+
+            result = await _sqlExecutor.ExecuteBackupPathAsync(result, options, token).ConfigureAwait(false);
+
+            if (token.IsCancellationRequested)
+            {
+                result.Result = false;
+                result.Messages.Add(ExecutionCancelledMessage);
+                return result;
+            }
+
+            // If result of path execution is not true, we want to strip out the path, so we only have the backup name.
+            if (!result.Result)
+            {
+                result.Messages.Add("Unable to check the path, reverting to default save path.");
+                options.RemovePathFromBackupLocation();
+            }
+            
+            result = await _sqlExecutor.ExecuteBackupDatabaseAsync(result, options, token).ConfigureAwait(false);
+
+            if (!token.IsCancellationRequested) return result;
+
+            result.Result = false;
+            result.Messages.Add(ExecutionCancelledMessage);
+            return result;
+        }
+    }
 }

--- a/DatabaseOperations/Wrappers/SqlCommandWrapper.cs
+++ b/DatabaseOperations/Wrappers/SqlCommandWrapper.cs
@@ -1,4 +1,6 @@
 ﻿using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
 using DatabaseOperations.Interfaces;
 using Microsoft.Data.SqlClient;
 
@@ -26,6 +28,11 @@ namespace DatabaseOperations.Wrappers
         public int ExecuteNonQuery()
         {
             return _sqlCommand.ExecuteNonQuery();
+        }
+
+        public async Task<int> ExecuteNonQueryAsync(CancellationToken token)
+        {
+            return await _sqlCommand.ExecuteNonQueryAsync(token).ConfigureAwait(false);
         }
 
         public void SetCommandTimeout(int timeout)

--- a/DatabaseOperations/Wrappers/SqlConnectionWrapper.cs
+++ b/DatabaseOperations/Wrappers/SqlConnectionWrapper.cs
@@ -1,4 +1,6 @@
-﻿using DatabaseOperations.Interfaces;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DatabaseOperations.Interfaces;
 using Microsoft.Data.SqlClient;
 
 namespace DatabaseOperations.Wrappers
@@ -20,6 +22,11 @@ namespace DatabaseOperations.Wrappers
         public void Open()
         {
             _sqlConnection.Open();
+        }
+
+        public async Task OpenAsync(CancellationToken token)
+        {
+            await _sqlConnection.OpenAsync(token).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ var result = backupOperator.BackupDatabase(new ConnectionOptions(connectionStrin
 To perform the backup asynchronously (for many backup operations):
 
 ```csharp
-const string connectionStringOne = @"server=MADDY\SQLDEV;database=DatabaseOne;Integrated Security=SSPI;Connect Timeout=5;";
-const string connectionStringTwo = @"server=MADDY\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
-const string connectionStringThree = @"server=MADDY\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
+const string connectionStringOne = @"server=MyComputer\SQLDEV;database=DatabaseOne;Integrated Security=SSPI;Connect Timeout=5;";
+const string connectionStringTwo = @"server=MyComputer\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
+const string connectionStringThree = @"server=MyComputer\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
 const string backupPath = @"E:\Database\Backups\";
 var cancellationSource = new CancellationTokenSource();
 var token = cancellationSource.Token;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To create a new instance of the `BackupOperator`:
 var backupOperator = new BackupOperator();
 ```
 
-To perform the backup operation:
+To perform the backup operation synchronously:
 
 ```csharp
 const string connectionString = @"server=MyComputer\SQLDEV;database=TestDatabase;Integrated Security=SSPI;Connect Timeout=5;";
@@ -33,6 +33,35 @@ const string backupPath = @"E:\Database\Backups\";
 
 var result = backupOperator.BackupDatabase(new ConnectionOptions(connectionString, backupPath));
 ```
+
+To perform the backup asynchronously (for many backup operations):
+
+```csharp
+const string connectionStringOne = @"server=MADDY\SQLDEV;database=DatabaseOne;Integrated Security=SSPI;Connect Timeout=5;";
+const string connectionStringTwo = @"server=MADDY\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
+const string connectionStringThree = @"server=MADDY\SQLDEV;database=DatabaseTwo;Integrated Security=SSPI;Connect Timeout=5;";
+const string backupPath = @"E:\Database\Backups\";
+var cancellationSource = new CancellationTokenSource();
+var token = cancellationSource.Token;
+
+var resultOne = backupOperator.BackupDatabaseAsync(new ConnectionOptions(connectionStringOne, backupPath), token);
+var resultTwo = backupOperator.BackupDatabaseAsync(new ConnectionOptions(connectionStringTwo, backupPath), token);
+var resultThree = backupOperator.BackupDatabaseAsync(new ConnectionOptions(connectionStringThree, backupPath), token);
+
+await Task.WhenAll(resultOne, resultTwo, resultThree).ConfigureAwait(false);
+
+var taskOne = await resultOne.ConfigureAwait(false);
+var taskTwo = await resultTwo.ConfigureAwait(false);
+var taskThree = await resultThree.ConfigureAwait(false);
+```
+
+### Cancellation of the operation
+
+The `CancellationTokenSource` object can be created with a timeout in milliseconds, or a `TimeSpan`.
+
+The token source can be cancelled from any event, or when the timeout is reached.
+
+If no token is supplied to the call, it will create one, but the calling application will not be able to raise the cancellation of the task.
 
 ## Milestones
 


### PR DESCRIPTION
The SQL execution is capable of executing using the `aynsc`/`await` pattern.

This PR is for the addition of the async versions of the existing methods already created.

Adds feature from #9 